### PR TITLE
change number of lookup groups in the fusion sheet

### DIFF
--- a/resources/home/dnanexus/configs/sv.py
+++ b/resources/home/dnanexus/configs/sv.py
@@ -99,19 +99,19 @@ def add_dynamic_values(data: pd.DataFrame, alternative_columns: dict) -> dict:
         misc.convert_letter_column_to_index(last_column_letter),
     )
 
-    total_number_genes = last_column_index - 1 - lookup_start
+    total_number_genes = last_column_index - lookup_start + 1
 
     # there are 12 look up groups
-    if total_number_genes % 12:
+    if total_number_genes % 13:
         raise ValueError(
             (
                 "Uneven number of genes per lookup group: "
-                f"{total_number_genes} / 12 = {total_number_genes/12} per "
+                f"{total_number_genes} / 13 = {total_number_genes/13} per "
                 "group"
             )
         )
 
-    number_genes = total_number_genes // 12
+    number_genes = total_number_genes // 13
 
     number_genes = int(number_genes)
     lookup_end = last_column_index - number_genes


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_solid_cancer_wgs_workbook/33)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for calculating and validating gene lookup groups, increasing the expected number of groups from 12 to 13 and updating related error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->