### PR TITLE
add regex to filter out non numerical elements in the clinvar ids

### DIFF
--- a/resources/home/dnanexus/tests/test_excel_parsing.py
+++ b/resources/home/dnanexus/tests/test_excel_parsing.py
@@ -18,7 +18,7 @@ def germline_variant_data():
                 "coor2",
                 "coor3",
             ],
-            "ClinVar ID": ["id1", "", "id2"],
+            "ClinVar ID": ["1", "", "2"],
             "Population germline allele frequency (GE | gnomAD)": [
                 "ge1|freq1",
                 "",
@@ -254,7 +254,7 @@ class TestProcessReportedVariantsGermline:
     ):
         mock_vcf_data.return_value = pd.DataFrame(
             {
-                "ClinVar ID": ["id1"],
+                "ClinVar ID": ["1"],
                 "clnsigconf": ["sig1"],
             }
         )
@@ -289,7 +289,7 @@ class TestProcessReportedVariantsGermline:
     ):
         mock_vcf_data.return_value = pd.DataFrame(
             {
-                "ClinVar ID": ["id1", "id2"],
+                "ClinVar ID": ["1", "2"],
                 "clnsigconf": ["sig1", "sig2"],
             }
         )

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -63,6 +63,7 @@ def process_reported_variants_germline(
     # the automatic conversion that pandas applies added
     df["ClinVar ID"] = df["ClinVar ID"].astype("string")
     df["ClinVar ID"] = df["ClinVar ID"].str.removesuffix(".0")
+    df["ClinVar ID"] = df["ClinVar ID"].str.replace(r"[^0-9]", "", regex=True)
 
     df.reset_index(drop=True, inplace=True)
 


### PR DESCRIPTION
Fix #35

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_solid_cancer_wgs_workbook/40)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data cleaning for the "ClinVar ID" column in reported variants, ensuring only numeric characters are retained. This enhances data accuracy when displaying or processing ClinVar information.  
  * Updated test data to reflect refined "ClinVar ID" formatting, supporting consistent validation of variant processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->