### PR TITLE
DI-2409

### DIFF
--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -515,7 +515,7 @@ def process_fusion_SV(
     )
 
     # get gene counts and look up for each gene
-    max_num_gene = df_SV["Gene"].str.count(r"\;").max() + 1
+    max_num_gene = df_SV["Fusion_no_duplicate"].str.count(r"\;").max() + 1
 
     gene_col = []
 


### PR DESCRIPTION
Fix bug where discrepancy in the number of unique genes and the number of counted genes caused failure of the app. Fixes #69 


- max_num_genes now calculated using Fusion_no_duplicates column

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_solid_cancer_wgs_workbook/72)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Gene fusion results in Excel outputs now deduplicate fusion partners before creating Gene_1..Gene_N columns.
  - Eliminates duplicate tokens and ensures columns reflect unique partners, improving readability and downstream filtering.

- Documentation
  - None.

- Refactor
  - None.

- Tests
  - None.

- Chores
  - None.

- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->