### PR TITLE
Di 2407

### DIFF
--- a/resources/home/dnanexus/configs/summary.py
+++ b/resources/home/dnanexus/configs/summary.py
@@ -190,6 +190,13 @@ CONFIG = {
     }
     # somatic cnv gain variant class
     | {(row, 6): f"=L{row+44}" for row in range(37, 42)}
+
+    #  somatic cnv gain comments
+    | {
+        (row, 8): f'=SUBSTITUTE(M{row+44},";",CHAR(10))'
+        for row in range(37, 42)
+    }
+
     ####
     # somatic cnv loss lookup
     | {
@@ -213,6 +220,12 @@ CONFIG = {
     }
     # somatic cnv loss variant class
     | {(row, 6): f"=L{row+47}" for row in range(42, 47)}
+    #  somatic cnv loss comments
+    | {
+        (row, 8): f'=SUBSTITUTE(M{row+47},";",CHAR(10))'
+        for row in range(42, 47)
+    }
+
     ####
     # somatic fusion gene lookup
     | {
@@ -566,6 +579,11 @@ def add_dynamic_values(
                 ]
             )
             + ")"
+            for row in range(47, 52)
+        }
+        # cyto columns are dynamic, but comments for SV are 3rd column after last cyto column
+        | {
+            (row, 8): f'=SUBSTITUTE({misc.convert_index_to_letters(max(cytos_column_index)+3)}{row+50},";",CHAR(10))'
             for row in range(47, 52)
         }
         | {

--- a/resources/home/dnanexus/configs/summary.py
+++ b/resources/home/dnanexus/configs/summary.py
@@ -160,6 +160,13 @@ CONFIG = {
     }
     # somatic snv variant class
     | {(row, 6): f"=N{row+44}" for row in range(25, 34)}
+
+    #  somatic snv comments
+    | {
+        (row, 8): f'=SUBSTITUTE(O{row+44},";",CHAR(10))'
+        for row in range(25, 34)
+    }
+
     ####
     # somatic cnv gain lookup
     | {

--- a/resources/home/dnanexus/generate_workbook.py
+++ b/resources/home/dnanexus/generate_workbook.py
@@ -190,11 +190,11 @@ def main(**kwargs):
         },
         {"sheet_name": "Plot", "html_images": html_images},
         {"sheet_name": "Signatures", "html_images": html_images},
+        {"sheet_name": "Germline", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "SNV", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "Gain", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "Loss", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "SV", "dynamic_data": dynamic_values_per_sheet},
-        {"sheet_name": "Germline", "dynamic_data": dynamic_values_per_sheet},
         {
             "sheet_name": "Summary",
             "dynamic_data": dynamic_values_per_sheet,

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -559,17 +559,15 @@ def process_fusion_SV(
     # Want to reorder selected columns to group Driver and Entities of the same gene together for each lookup group
     lookup_reorder = []
     # Lookup column types
-    for col_type in ["COSMIC", "Paed", "Sarc", "Neuro", "Ovary", "Haem"]:
+    for lookup_type in ["COSMIC", "Paed", "Sarc", "Neuro", "Ovary", "Haem"]:
         # find Gene 1, then Gene 2 etc
         for gene_num in range(1, max_num_gene +1):
             # [\w\s]* any aphanumeric character and any whitespace character multiple times
             # will catch " Driver\n" and " Entities\n"
-            string_to_match= col_type + "[\w\s]*Gene_" + str(gene_num)
+            string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num)
             pattern = re.compile(string_to_match)
             cols = list(filter(pattern.match,lookup_cols))
             lookup_reorder.extend(cols)
-
-    #   move cosmic entitties 1 next to cosmic driver 2 
 
     df_SV.loc[:, "Variant class"] = ""
     df_SV.loc[:, "Comments"] = ""


### PR DESCRIPTION
Reformatting and adding comments for Summary tables
Changes:
- Move the germline sheet to between signatures and snv
- For the SV sheet, group driver and entities for the same gene together for each lookup column
- In the summary sheet, link comments from into the summary table comment column

Fixes issues:
- #61 
- #70 
- #68 