### PR TITLE
V2.0.3

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
     "name": "eggd_generate_solid_cancer_wgs_workbook",
     "title": "eggd_generate_solid_cancer_wgs_workbook",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "summary": "Generates a workbook for solid cancer WGS data analysis",
     "dxapi": "1.0.0",
     "inputSpec": [

--- a/resources/home/dnanexus/configs/snv.py
+++ b/resources/home/dnanexus/configs/snv.py
@@ -173,13 +173,13 @@ def add_dynamic_values(data: pd.DataFrame) -> dict:
         "data_bar": f"J2:J{nb_somatic_variants + 1}",
         "borders": {
             "cell_rows": [
-                (f"Z1:Z{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AB1:AB{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AD1:AD{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AF1:AF{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AH1:AH{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AJ1:AJ{nb_somatic_variants+1}", LEFT_BORDER),
-                (f"AL1:AL{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AA1:AA{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AC1:AC{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AE1:AE{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AG1:AG{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AI1:AI{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AK1:AK{nb_somatic_variants+1}", LEFT_BORDER),
+                (f"AM1:AM{nb_somatic_variants+1}", LEFT_BORDER),
             ],
         },
     }

--- a/resources/home/dnanexus/configs/summary.py
+++ b/resources/home/dnanexus/configs/summary.py
@@ -190,6 +190,13 @@ CONFIG = {
     }
     # somatic cnv gain variant class
     | {(row, 6): f"=L{row+44}" for row in range(37, 42)}
+
+    #  somatic cnv gain comments
+    | {
+        (row, 8): f'=SUBSTITUTE(M{row+44},";",CHAR(10))'
+        for row in range(37, 42)
+    }
+
     ####
     # somatic cnv loss lookup
     | {
@@ -213,6 +220,12 @@ CONFIG = {
     }
     # somatic cnv loss variant class
     | {(row, 6): f"=L{row+47}" for row in range(42, 47)}
+    #  somatic cnv loss comments
+    | {
+        (row, 8): f'=SUBSTITUTE(M{row+47},";",CHAR(10))'
+        for row in range(42, 47)
+    }
+
     ####
     # somatic fusion gene lookup
     | {
@@ -566,6 +579,11 @@ def add_dynamic_values(
                 ]
             )
             + ")"
+            for row in range(47, 52)
+        }
+        # cyto columns are dynamic, but comments for SV are 3rd column after last cyto column
+        | {
+            (row, 8): f'=SUBSTITUTE({misc.convert_index_to_letters(max(cytos_column_index)+3)}{row+50},";",CHAR(10))'
             for row in range(47, 52)
         }
         | {

--- a/resources/home/dnanexus/configs/summary.py
+++ b/resources/home/dnanexus/configs/summary.py
@@ -160,6 +160,13 @@ CONFIG = {
     }
     # somatic snv variant class
     | {(row, 6): f"=N{row+44}" for row in range(25, 34)}
+
+    #  somatic snv comments
+    | {
+        (row, 8): f'=SUBSTITUTE(O{row+44},";",CHAR(10))'
+        for row in range(25, 34)
+    }
+
     ####
     # somatic cnv gain lookup
     | {

--- a/resources/home/dnanexus/configs/sv.py
+++ b/resources/home/dnanexus/configs/sv.py
@@ -124,8 +124,10 @@ def add_dynamic_values(data: pd.DataFrame, alternative_columns: dict) -> dict:
     # build the info for borders in the lookup groups
     # +2 in order to add a left border between the lookup groups and the gene
     # columns
+    # number_genes*2 to add borders at start and end of each lookup group
+    # rather than between drivers and entities of each lookup
     for i, index in enumerate(range(lookup_start, last_column_index + 2)):
-        if i % number_genes == 0:
+        if i % (number_genes*2) == 0:
             col_letter = misc.convert_index_to_letters(index)
             border_cells.append(
                 (

--- a/resources/home/dnanexus/generate_workbook.py
+++ b/resources/home/dnanexus/generate_workbook.py
@@ -190,11 +190,11 @@ def main(**kwargs):
         },
         {"sheet_name": "Plot", "html_images": html_images},
         {"sheet_name": "Signatures", "html_images": html_images},
+        {"sheet_name": "Germline", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "SNV", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "Gain", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "Loss", "dynamic_data": dynamic_values_per_sheet},
         {"sheet_name": "SV", "dynamic_data": dynamic_values_per_sheet},
-        {"sheet_name": "Germline", "dynamic_data": dynamic_values_per_sheet},
         {
             "sheet_name": "Summary",
             "dynamic_data": dynamic_values_per_sheet,

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -515,7 +515,7 @@ def process_fusion_SV(
     )
 
     # get gene counts and look up for each gene
-    max_num_gene = df_SV["Gene"].str.count(r"\;").max() + 1
+    max_num_gene = df_SV["Fusion_no_duplicate"].str.count(r"\;").max() + 1
 
     gene_col = []
 

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -559,17 +559,15 @@ def process_fusion_SV(
     # Want to reorder selected columns to group Driver and Entities of the same gene together for each lookup group
     lookup_reorder = []
     # Lookup column types
-    for col_type in ["COSMIC", "Paed", "Sarc", "Neuro", "Ovary", "Haem"]:
+    for lookup_type in ["COSMIC", "Paed", "Sarc", "Neuro", "Ovary", "Haem"]:
         # find Gene 1, then Gene 2 etc
         for gene_num in range(1, max_num_gene +1):
             # [\w\s]* any aphanumeric character and any whitespace character multiple times
             # will catch " Driver\n" and " Entities\n"
-            string_to_match= col_type + "[\w\s]*Gene_" + str(gene_num)
+            string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num)
             pattern = re.compile(string_to_match)
             cols = list(filter(pattern.match,lookup_cols))
             lookup_reorder.extend(cols)
-
-    #   move cosmic entitties 1 next to cosmic driver 2 
 
     df_SV.loc[:, "Variant class"] = ""
     df_SV.loc[:, "Comments"] = ""

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -562,7 +562,7 @@ def process_fusion_SV(
     for lookup_type in ["COSMIC", "Paed", "Sarc", "Neuro", "Ovary", "Haem"]:
         # find Gene 1, then Gene 2 etc
         for gene_num in range(1, max_num_gene +1):
-            # [\w\s]* any aphanumeric character and any whitespace character multiple times
+            # [\w\s]* any alphanumeric character and any whitespace character multiple times
             # will catch " Driver\n" and " Entities\n"
             string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num)
             pattern = re.compile(string_to_match)


### PR DESCRIPTION
Pulling v2.0.3 changes into main 
Changes:
- Fix formatting issues
- Fix bug with mismatched total number of genes in SV tab
- Reorder tabs so germline tab is between Signatures and SNVs
- Group lookup Driver and entities by gene in SV tab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_solid_cancer_wgs_workbook/75)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Comments fields across somatic sections; semicolon-separated values now display on new lines.
  - Reordered fusion lookup columns by type and gene for clearer grouping; Gene columns count now reflects unique fusions.

- Style
  - Adjusted border placement in SNV and SV sections for clearer group delineation.

- Refactor
  - Moved the Germline sheet earlier in the workbook sequence; removed duplicate entry.

- Chores
  - Bumped application version to 2.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->