### PR TITLE
V2.0.4 fix lookup reorder regex

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
     "name": "eggd_generate_solid_cancer_wgs_workbook",
     "title": "eggd_generate_solid_cancer_wgs_workbook",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "summary": "Generates a workbook for solid cancer WGS data analysis",
     "dxapi": "1.0.0",
     "inputSpec": [

--- a/resources/home/dnanexus/utils/excel_parsing.py
+++ b/resources/home/dnanexus/utils/excel_parsing.py
@@ -564,7 +564,7 @@ def process_fusion_SV(
         for gene_num in range(1, max_num_gene +1):
             # [\w\s]* any alphanumeric character and any whitespace character multiple times
             # will catch " Driver\n" and " Entities\n"
-            string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num)
+            string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num) + "$"
             pattern = re.compile(string_to_match)
             cols = list(filter(pattern.match,lookup_cols))
             lookup_reorder.extend(cols)


### PR DESCRIPTION
Changes:
- Increase app version
- Fix regex bug.

Current regex for reordering lookup columns to group driver and entities for each gene uses the following string:
`string_to_match= lookup_type + "[\w\s]*Gene_" + str(gene_num)`
If the maximum number of genes involved in a fusion is >10 this will cause issues as a sting where gene_num = 1, will match Gene_1, Gene_10, Gene_11, Gene_12, Gene_13 etc, leading to duplicate columns
Adding `$` to the end of the regex string means `gene_num = 1` will only match `Gene_1` columns as the `$` indicates the end of a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_solid_cancer_wgs_workbook/77)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 2.0.4

* **Bug Fixes**
  * Improved precision in pattern matching for fusion structural variant data processing to ensure accurate column selection and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->